### PR TITLE
ci: github actions ci

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,29 @@
+name: Actions 😎
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          lfs: true
+      - name: Cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+      - name: Unity - Builder
+        uses: game-ci/unity-builder@v2.0-alpha-13
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          targetPlatform: StandaloneWindows64
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Udało mi się skonfigurować CI dla Unity.
Wszystko widoczne jest na moim publicznym forku, obczajcie tam: https://github.com/kmichonsk/UnityVRPrototype/actions

@Caerglad  będę potrzebował dostępu wyższego do tego repo żeby ustalić na nim sekrety do tego CI (licencja i dostęp do niej).